### PR TITLE
Fix flaky test in JSONUtilTest.

### DIFF
--- a/infra/common/src/test/java/cn/hippo4j/common/toolkit/JSONUtilTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/toolkit/JSONUtilTest.java
@@ -24,6 +24,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.junit.Assert;
 import org.junit.Test;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,7 +44,11 @@ public class JSONUtilTest {
     @Test
     public void assertToJSONString() {
         Assert.assertNull(JSONUtil.toJSONString(null));
-        Assert.assertEquals(EXPECTED_FOO_JSON, JSONUtil.toJSONString(EXPECTED_FOO));
+        try {
+            JSONAssert.assertEquals(EXPECTED_FOO_JSON, JSONUtil.toJSONString(EXPECTED_FOO), false);
+        } catch (JSONException jse) {
+            throw new RuntimeException(jse);
+        }
     }
 
     @Test


### PR DESCRIPTION
Use JSONAssert instead of Assert in JSONUtilTest to fix a flaky test

**Flaky test case:** cn.hippo4j.common.toolkit.JSONUtilTest.cn.hippo4j.common.toolkit.JSONUtilTest.assertToJSONString
https://github.com/bbelide2/hippo4j/blob/d645c49450ca3daec8eea5be8e5f9921116d42ac/infra/common/src/test/java/cn/hippo4j/common/toolkit/JSONUtilTest.java#L43

### Problem

Test ```assertToJSONString``` in ```JSONUtilTest``` is detected as flaky with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed with the following error:


```
Failed tests: assertToJSONString(cn.hippo4j.common.toolkit.JSONUtilTest): expected:<{"[id":1,"name":"foo1","foo":{"id":2,"name":"foo2"}]}> but was:<{"[foo":{"id":2,"name":"foo2"},"id":1,"name":"foo1"]}>
```

### Root cause

In this test, two JSON strings are compared using Assert.assertEquals() in this part of the code: 

https://github.com/bbelide2/hippo4j/blob/d645c49450ca3daec8eea5be8e5f9921116d42ac/infra/common/src/test/java/cn/hippo4j/common/toolkit/JSONUtilTest.java#L45

Using Assert.assertEquals() will lead to flaky tests due to mismatch in the order of properties or if there are nested structures. In this particular test case, JSON object(Foo) contains a nested object of the same type leading to difference in the order of properties thus making it a flaky test.

In this test, a hardcoded JSON string "EXPECTED_FOO_JSON" is compared with another JSON string created by JSONUtil.toJSONString(). The input to this method is an object of class Foo (test class present in JSONUtilTest). 

### Fix

Changed Assert.assertEquals() to JSONAssert.assertEquals() which is order insensitive. 


### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl infra/common -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl infra/common test -Dtest=cn.hippo4j.common.toolkit.JSONUtilTest#assertToJSONString
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl infra/common edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=cn.hippo4j.common.toolkit.JSONUtilTest#assertToJSONString
```

NonDex test passed after the fix.

### Alternate fix

Add @JsonPropertyOrder({"id", "name", "foo"}) annotation to Foo class so that the order of properties whenever an object of this class is converted to JSON string remains same. Since the order now always remains same, the JSON string always matches with our expected string thus fixing the flaky test. This change will not impact code since Foo class is only used in tests.


