### PR TITLE
Fix flaky test in HttpUtilsTest

### DIFF
--- a/infra/common/src/test/java/cn/hippo4j/common/toolkit/http/HttpUtilsTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/toolkit/http/HttpUtilsTest.java
@@ -37,7 +37,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class HttpUtilsTest {
@@ -169,7 +169,7 @@ public class HttpUtilsTest {
 
     @Test
     public void buildUrl() {
-        Map<String, String> map = new HashMap<>();
+        Map<String, String> map = new LinkedHashMap<>();
         map.put(password, passwordValue);
         map.put(username, usernameValue);
         String s = HttpUtil.buildUrl(url + PORT, map);


### PR DESCRIPTION
Use LinkedHashMap instead of HashMap in HttpUtilsTest class to fix a flaky test.

**Flaky test case:** cn.hippo4j.common.toolkit.http.HttpUtilsTest.buildUrl

https://github.com/bbelide2/hippo4j/blob/cf854b3cb3c47fd339421e5a46a3ae3229c53829/infra/common/src/test/java/cn/hippo4j/common/toolkit/http/HttpUtilsTest.java#L171


### Problem

Test ```buildUrl()``` in ```HttpUtilsTest``` is detected as flaky with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed with the following error:


```
Failed tests:   buildUrl(cn.hippo4j.common.toolkit.http.HttpUtilsTest): expected:<...p://localhost:39553?[password=hippo4jtest&username=hippo4j]> but was:<...p://localhost:39553?[username=hippo4j&password=hippo4jtest]>
```


### Root cause

In this test, username and password values (strings) are inserted into a HashMap and this map is sent as a parameter to ```HttpUtil.buildUrl``` function along with url and port string. 

https://github.com/bbelide2/hippo4j/blob/cf854b3cb3c47fd339421e5a46a3ae3229c53829/infra/common/src/test/java/cn/hippo4j/common/toolkit/http/HttpUtilsTest.java#L172-L174

The output is compared with a hardcoded string (url with port and password-username suffix). Since HashMaps theoretically do not preserve the order of elements, we get different map element order in different tests (when the elements are shuffled in NonDex). Therefore, the test becomes flaky and fails with NonDex tool.

### Fix

This problem is fixed by using LinkedHashMap instead of HashMap to keep the order deterministic. Test passed after the fix.

This fix will not affect any part of the code since this change is only in test class.

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl infra/common -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl infra/common test -Dtest=cn.hippo4j.common.toolkit.http.HttpUtilsTest#buildUrl
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl infra/common edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=10 -Dtest=cn.hippo4j.common.toolkit.http.HttpUtilsTest#buildUrl
```

NonDex test passed after the fix.