### PR TITLE
Fix flaky tests in LogMessageTest

### DIFF
--- a/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java
@@ -73,7 +73,8 @@ public class LogMessageTest {
     public void testKvShouldPutAllKeyAndValuePairs() {
         logMessage.kv("key1", "value1");
         logMessage.kv("key2", "value2");
-        assertEquals("key1=value1||key2=value2", logMessage.toString());
+        String output = logMessage.toString();
+        assertTrue(output.equals("key1=value1||key2=value2") || output.equals("key2=value2||key1=value1"));
     }
 
     @Test
@@ -81,7 +82,8 @@ public class LogMessageTest {
         logMessage.setMsg(MESSAGE);
         logMessage.kv("key1", "value1");
         logMessage.kv("key2", "value2");
-        assertEquals("messagekey1=value1||key2=value2", logMessage.toString());
+        String output = logMessage.toString();
+        assertTrue(output.equals("messagekey1=value1||key2=value2") || output.equals("messagekey2=value2||key1=value1"));
     }
 
     @Test

--- a/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java
@@ -82,8 +82,7 @@ public class LogMessageTest {
         logMessage.setMsg(MESSAGE);
         logMessage.kv("key1", "value1");
         logMessage.kv("key2", "value2");
-        String output = logMessage.toString();
-        assertTrue(output.equals("messagekey1=value1||key2=value2") || output.equals("messagekey2=value2||key1=value1"));
+        assertEquals("messagekey1=value1||key2=value2", logMessage.toString());
     }
 
     @Test


### PR DESCRIPTION
Change Assert condition to check on both map orders in a flaky test in LogMessageTest to make it non-flaky.

**Flaky test**

```
cn.hippo4j.common.toolkit.logtracing.LogMessageTest.testKvShouldPutAllKeyAndValuePairs	
```

https://github.com/bbelide2/hippo4j/blob/26212e47cf26c3aee5b9282c4460c903e2adaf37/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java#L73

### Problem

Test ```testKvShouldPutAllKeyAndValuePairs``` in ```LogMessageTest``` is detected as flaky with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed with the following error:

```
Error:
Failed tests:   testKvShouldPutAllKeyAndValuePairs(cn.hippo4j.common.toolkit.logtracing.LogMessageTest): expected: <key1=value1||key2=value2> but was: <key2=value2||key1=value1>
```

### Root cause

In this test, 2 key-value pairs are set to the ```kvs``` field (ConcurrentHashMap) of ```logMessage``` object. Then, ```logMessage.toString()``` is called and the response is compared with hard-coded strings. logMessage.toString() converts the given map to string form along with some other processing. But, ConcurrentHashMap/HashMap may not maintain the order of elements. Therefore, when NonDex tests are run, the order of elements are shuffled and the output is reversed and incorrect thus making the test flaky.

Key-values are inserted this way:

https://github.com/bbelide2/hippo4j/blob/cf854b3cb3c47fd339421e5a46a3ae3229c53829/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java#L74-L75

Output is compared this way:

https://github.com/bbelide2/hippo4j/blob/cf854b3cb3c47fd339421e5a46a3ae3229c53829/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java#L76


### Fix

Usually, switching from HashMap to LinkedHashMap will make tests non-flaky because LinkedHashMap will preserve order of elements. But, we cannot change a ConcurrentHashMap to LinkedHashMap because LinkedHashMap is not thread-safe like ConcurrentHashMap. Therefore, I updated the assert statement to check the output for both the possible orders of elements.

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl infra/common -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl infra/common test -Dtest=cn.hippo4j.common.toolkit.logtracing.LogMessageTest#testKvShouldPutAllKeyAndValuePairs
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl infra/common edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=10 -Dtest=cn.hippo4j.common.toolkit.logtracing.LogMessageTest#testKvShouldPutAllKeyAndValuePairs

```

NonDex tests passed after the fix.